### PR TITLE
Fix: Resolve all ruff linting errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,10 @@ htmlcov/
 *.cover
 .hypothesis/
 
+# Linting and formatting
+.ruff_cache/
+.mypy_cache/
+
 # Logs
 logs/
 *.log

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,8 @@ target-version = ["py310", "py311", "py312"]
 [tool.ruff]
 line-length = 100
 target-version = "py310"
+
+[tool.ruff.lint]
 select = ["E", "F", "I", "N", "W", "UP"]
 
 [tool.mypy]

--- a/src/ali/config/settings.py
+++ b/src/ali/config/settings.py
@@ -1,7 +1,6 @@
 """Application settings and configuration management."""
 
 from pathlib import Path
-from typing import Optional
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -68,7 +67,7 @@ class AppSettings(BaseSettings):
 
 
 # Global settings instance
-_settings: Optional[AppSettings] = None
+_settings: AppSettings | None = None
 
 
 def get_settings() -> AppSettings:

--- a/src/ali/core/services.py
+++ b/src/ali/core/services.py
@@ -3,8 +3,6 @@
 import shutil
 import subprocess
 import time
-from pathlib import Path
-from typing import Optional
 
 import requests
 from loguru import logger
@@ -159,7 +157,7 @@ class OllamaService:
         models = self.list_models()
         return model_name in models
 
-    def suggest_model(self) -> Optional[str]:
+    def suggest_model(self) -> str | None:
         """Suggest a model to use based on what's available.
 
         Returns:

--- a/src/ali/llm/client.py
+++ b/src/ali/llm/client.py
@@ -1,6 +1,6 @@
 """Ollama LLM client wrapper."""
 
-from typing import AsyncIterator, Optional
+from collections.abc import AsyncIterator
 
 import ollama
 from loguru import logger
@@ -11,7 +11,7 @@ from ali.config.settings import OllamaSettings
 class OllamaClient:
     """Wrapper for Ollama API client."""
 
-    def __init__(self, settings: Optional[OllamaSettings] = None) -> None:
+    def __init__(self, settings: OllamaSettings | None = None) -> None:
         """Initialize Ollama client.
 
         Args:
@@ -24,9 +24,9 @@ class OllamaClient:
     def chat(
         self,
         message: str,
-        model: Optional[str] = None,
-        system_prompt: Optional[str] = None,
-        temperature: Optional[float] = None,
+        model: str | None = None,
+        system_prompt: str | None = None,
+        temperature: float | None = None,
     ) -> str:
         """Send a chat message and get response.
 
@@ -65,9 +65,9 @@ class OllamaClient:
     async def chat_stream(
         self,
         message: str,
-        model: Optional[str] = None,
-        system_prompt: Optional[str] = None,
-        temperature: Optional[float] = None,
+        model: str | None = None,
+        system_prompt: str | None = None,
+        temperature: float | None = None,
     ) -> AsyncIterator[str]:
         """Send a chat message and stream response.
 

--- a/src/ali/main.py
+++ b/src/ali/main.py
@@ -88,11 +88,11 @@ def main() -> None:
             model=model_to_use,
         )
 
-        print("\n" + "="*50)
+        print("\n" + "=" * 50)
         print("ALI Response:")
-        print("="*50)
+        print("=" * 50)
         print(response)
-        print("="*50 + "\n")
+        print("=" * 50 + "\n")
 
         logger.info("Test completed successfully")
 

--- a/src/ali/main.py
+++ b/src/ali/main.py
@@ -1,7 +1,6 @@
 """Main entry point for ALI application."""
 
 import sys
-from pathlib import Path
 
 from loguru import logger
 
@@ -21,7 +20,10 @@ def setup_logging() -> None:
     logger.add(
         sys.stderr,
         level=settings.log_level,
-        format="<green>{time:YYYY-MM-DD HH:mm:ss}</green> | <level>{level: <8}</level> | <level>{message}</level>",
+        format=(
+            "<green>{time:YYYY-MM-DD HH:mm:ss}</green> | "
+            "<level>{level: <8}</level> | <level>{message}</level>"
+        ),
     )
 
     # Add file handler


### PR DESCRIPTION
Fixes all linting errors found by ruff in CI/CD pipeline.

## Changes
- Use modern Python 3.10+ type hints (`X | None` instead of `Optional[X]`)
- Remove unused imports (`Path`)
- Fix line length violations (split long format strings)
- Move ruff config to `[tool.ruff.lint]` section (new format)
- Import `AsyncIterator` from `collections.abc` instead of `typing`
- Add `.ruff_cache/` and `.mypy_cache/` to gitignore

## Testing
- ✅ All 32 tests pass locally
- ✅ Ruff linting passes
- ✅ No breaking changes

Addresses #2